### PR TITLE
Update to "2024.4.1" docker tag; Accept themes, automations, and scenes configs/configmaps

### DIFF
--- a/charts/home-assistant/Chart.yaml
+++ b/charts/home-assistant/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2024.3"
+appVersion: "2024.4.1"
 
 maintainers:
   - name: "jessebot"

--- a/charts/home-assistant/README.md
+++ b/charts/home-assistant/README.md
@@ -22,14 +22,14 @@ A Helm chart for home assistant on Kubernetes
 | extraVolumeMounts | list | `[]` | Additional volumeMounts on the output Deployment definition. example device mount:   - mountPath: /dev/ttyACM0    name: usb |
 | extraVolumes | list | `[]` | Additional volumes on the output Deployment definition. example device as volume:   - hostPath:      path: >-        /dev/serial/by-id/usb-ITEAD_SONOFF_Zigbee_3.0_USB_Dongle_Plus_V2_20230509111242-if00      type: CharDevice    name: usb |
 | fullnameOverride | string | `""` |  |
-| homeAssistant.automations | string | `""` | contents of automations.yaml file to create |
+| homeAssistant.automations | string | `""` | contents of automations.yaml file to create, ignored if homeAssistant.existingAutomationsConfigMap set |
 | homeAssistant.configuration | string | `""` | any data you'd like to see put into your configuration.yaml # example config configuration: |   # this enables proxies such as the ingress nginx controller   http:     use_x_forwarded_for: true     trusted_proxies:       - 10.0.0.0/8   mobile:    config: |
-| homeAssistant.existingAutomationConfigMap | string | `""` | name of existing automations ConfigMap |
+| homeAssistant.existingAutomationsConfigMap | string | `""` | name of existing automations ConfigMap |
 | homeAssistant.existingConfigurationConfigMap | string | `""` | name of existing ConfigMap |
 | homeAssistant.existingScenesConfigMap | string | `""` | name of existing scenes ConfigMap |
 | homeAssistant.existingThemesConfigMap | string | `""` | name of existing themes ConfigMap |
-| homeAssistant.scenes | string | `""` | conents of scenes.yaml file to create |
-| homeAssistant.themes | string | `""` | contents of themes.yaml file to create |
+| homeAssistant.scenes | string | `""` | conents of scenes.yaml file to create, ignored if homeAssistant.existingScenesConfigMap set |
+| homeAssistant.themes | string | `""` | contents of themes.yaml file to create, ignored if homeAssistant.existingThemesConfigMap set |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"ghcr.io/home-assistant/home-assistant"` |  |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |

--- a/charts/home-assistant/README.md
+++ b/charts/home-assistant/README.md
@@ -1,6 +1,6 @@
 # home-assistant
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2024.3](https://img.shields.io/badge/AppVersion-2024.3-informational?style=flat-square)
+![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2024.4.1](https://img.shields.io/badge/AppVersion-2024.4.1-informational?style=flat-square)
 
 A Helm chart for home assistant on Kubernetes
 
@@ -9,12 +9,6 @@ A Helm chart for home assistant on Kubernetes
 | Name | Email | Url |
 | ---- | ------ | --- |
 | jessebot | <jessebot@linux.com> | <https://github.com/jessebot> |
-
-## Requirements
-
-| Repository | Name | Version |
-|------------|------|---------|
-| https://small-hack.github.io/home-assistant | deconz | 0.1.0 |
 
 ## Values
 
@@ -25,12 +19,17 @@ A Helm chart for home assistant on Kubernetes
 | autoscaling.maxReplicas | int | `100` |  |
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
-| deconz.enabled | bool | `false` | enable deconz for the conbee 1/2 for use with homeAssistant this can be obviated by setting extraVolumes/extraVolumeMounts/resouces if you have already installed the generic device plugin k8s daemonset.  otherwise, checkout the parameters available in here: https://github.com/small-hack/home-assistant-chart/tree/main/charts/deconz |
 | extraVolumeMounts | list | `[]` | Additional volumeMounts on the output Deployment definition. example device mount:   - mountPath: /dev/ttyACM0    name: usb |
 | extraVolumes | list | `[]` | Additional volumes on the output Deployment definition. example device as volume:   - hostPath:      path: >-        /dev/serial/by-id/usb-ITEAD_SONOFF_Zigbee_3.0_USB_Dongle_Plus_V2_20230509111242-if00      type: CharDevice    name: usb |
 | fullnameOverride | string | `""` |  |
-| homeAssistant.configuration | string | `""` | any data you'd like to see put into your configuration.yaml # example config configuration: |   # this enables proxies such as the ingress nginx controller   http:     use_x_forwarded_for: true     trusted_proxies:       - 10.0.0.0/8    mobile:    config: |
-| homeAssistant.existingConfigMap | string | `""` | name of existing Config Map |
+| homeAssistant.automations | string | `""` | contents of automations.yaml file to create |
+| homeAssistant.configuration | string | `""` | any data you'd like to see put into your configuration.yaml # example config configuration: |   # this enables proxies such as the ingress nginx controller   http:     use_x_forwarded_for: true     trusted_proxies:       - 10.0.0.0/8   mobile:    config: |
+| homeAssistant.existingAutomationConfigMap | string | `""` | name of existing automations ConfigMap |
+| homeAssistant.existingConfigurationConfigMap | string | `""` | name of existing ConfigMap |
+| homeAssistant.existingScenesConfigMap | string | `""` | name of existing scenes ConfigMap |
+| homeAssistant.existingThemesConfigMap | string | `""` | name of existing themes ConfigMap |
+| homeAssistant.scenes | string | `""` | conents of scenes.yaml file to create |
+| homeAssistant.themes | string | `""` | contents of themes.yaml file to create |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"ghcr.io/home-assistant/home-assistant"` |  |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |

--- a/charts/home-assistant/templates/automations-configmap.yaml
+++ b/charts/home-assistant/templates/automations-configmap.yaml
@@ -1,0 +1,13 @@
+{{- if and (not .Values.homeAssistant.existingAutomationsConfigMap ) .Values.homeAssistant.automations }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "home-assistant.fullname" . }}-automations
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-5"
+    helm.sh/resource-policy: keep
+data:
+  automations.yaml: |- {{ .Values.homeAssistant.automations | nindent 4 }}
+{{- end }}

--- a/charts/home-assistant/templates/configmap.yaml
+++ b/charts/home-assistant/templates/configmap.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.homeAssistant.existingConfigMap) .Values.homeAssistant.configuration }}
+{{- if and (not .Values.homeAssistant.existingConfigurationConfigMap ) .Values.homeAssistant.configuration }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/charts/home-assistant/templates/deployment.yaml
+++ b/charts/home-assistant/templates/deployment.yaml
@@ -40,9 +40,9 @@ spec:
             - "-c"
             - |
               cp /configYaml/configuration.yaml /config && \
-              cp /configYaml/themes.yaml /config || touch /config/themes.yaml && \
-              cp /configYaml/automations.yaml /config || touch /config/automations.yaml && \
-              cp /configYaml/scenes.yaml /config || touch /config/scenes.yaml
+              if test -f /configYaml/themes.yaml; then cp /configYaml/themes.yaml /config; else touch /config/themes.yaml; fi && \
+              if test -f /configYaml/automations.yaml; then cp /configYaml/automations.yaml /config; else touch /config/automations.yaml; fi && \
+              if test -f /configYaml/scenes.yaml; then cp /configYaml/scenes.yaml /config; else touch /config/scenes.yaml; fi
           volumeMounts:
             - name: config
               mountPath: /config

--- a/charts/home-assistant/templates/deployment.yaml
+++ b/charts/home-assistant/templates/deployment.yaml
@@ -39,26 +39,26 @@ spec:
             - "sh"
             - "-c"
             - |
-              cp /configYaml/configuration.yaml /config && \
-              if test -f /configYaml/themes.yaml; then cp /configYaml/themes.yaml /config; else touch /config/themes.yaml; fi && \
-              if test -f /configYaml/automations.yaml; then cp /configYaml/automations.yaml /config; else touch /config/automations.yaml; fi && \
-              if test -f /configYaml/scenes.yaml; then cp /configYaml/scenes.yaml /config; else touch /config/scenes.yaml; fi
+              cp /configYaml/config/configuration.yaml /config && \
+              if test -f /configYaml/themes/themes.yaml; then cp /configYaml/themes/themes.yaml /config; else touch /config/themes.yaml; fi && \
+              if test -f /configYaml/automations/automations.yaml; then cp /configYaml/automations/automations.yaml /config; else touch /config/automations.yaml; fi && \
+              if test -f /configYaml/scenes/scenes.yaml; then cp /configYaml/scenes/scenes.yaml /config; else touch /config/scenes.yaml; fi
           volumeMounts:
             - name: config
               mountPath: /config
-            - name: config-yaml
-              mountPath: /configYaml
+            - name: configuration-yaml
+              mountPath: /configYaml/config
             {{- if or .Values.homeAssistant.themes .Values.homeAssistant.existingThemesConfigMap }}
             - name: themes-yaml
-              mountPath: /configYaml
+              mountPath: /configYaml/themes
             {{- end }}
             {{- if or .Values.homeAssistant.automations .Values.homeAssistant.existingAutomationsConfigMap }}
             - name: automations-yaml
-              mountPath: /configYaml
+              mountPath: /configYaml/automations
             {{- end }}
             {{- if or .Values.homeAssistant.scenes .Values.homeAssistant.existingScenesConfigMap }}
             - name: scenes-yaml
-              mountPath: /configYaml
+              mountPath: /configYaml/scenes
             {{- end }}
       {{- end }}
       containers:
@@ -101,7 +101,7 @@ spec:
             claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{- else }}{{ include "home-assistant.name" . }}{{- end }}
       {{- end }}
       {{- if or .Values.homeAssistant.existingConfigurationConfigMap .Values.homeAssistant.configuration }}
-        - name: config-yaml
+        - name: configuration-yaml
           configMap:
             name: {{ if .Values.existingConfigurationConfigMap }}{{ .Values.homeAssistant.existingConfigurationConfigMap }}{{- else }}{{ include "home-assistant.name" . }}{{- end }}
       {{- end }}

--- a/charts/home-assistant/templates/deployment.yaml
+++ b/charts/home-assistant/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: {{ include "home-assistant.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      {{- if and .Values.homeAssistant.configuration .Values.persistence.enabled }}
+      {{- if and (or .Values.homeAssistant.configuration .Values.homeAssistant.existingConfigurationConfigMap) .Values.persistence.enabled }}
       initContainers:
         - name: config-creation
           image: alpine:latest
@@ -38,12 +38,28 @@ spec:
           command:
             - "sh"
             - "-c"
-            - "cp /configYaml/configuration.yaml /config"
+            - |
+              cp /configYaml/configuration.yaml /config && \
+              cp /configYaml/themes.yaml /config || touch /config/themes.yaml && \
+              cp /configYaml/automations.yaml /config || touch /config/automations.yaml && \
+              cp /configYaml/scenes.yaml /config || touch /config/scenes.yaml
           volumeMounts:
             - name: config
               mountPath: /config
             - name: config-yaml
               mountPath: /configYaml
+            {{- if or .Values.homeAssistant.themes .Values.homeAssistant.existingThemesConfigMap }}
+            - name: themes-yaml
+              mountPath: /configYaml
+            {{- end }}
+            {{- if or .Values.homeAssistant.automations .Values.homeAssistant.existingAutomationsConfigMap }}
+            - name: automations-yaml
+              mountPath: /configYaml
+            {{- end }}
+            {{- if or .Values.homeAssistant.scenes .Values.homeAssistant.existingScenesConfigMap }}
+            - name: scenes-yaml
+              mountPath: /configYaml
+            {{- end }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
@@ -84,10 +100,25 @@ spec:
           persistentVolumeClaim:
             claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{- else }}{{ include "home-assistant.name" . }}{{- end }}
       {{- end }}
-      {{- if or .Values.homeAssistant.existingConfigMap .Values.homeAssistant.configuration }}
+      {{- if or .Values.homeAssistant.existingConfigurationConfigMap .Values.homeAssistant.configuration }}
         - name: config-yaml
           configMap:
-            name: {{ if .Values.existingConfigMap }}{{ .Values.homeAssistant.existingConfigMap }}{{- else }}{{ include "home-assistant.name" . }}{{- end }}
+            name: {{ if .Values.existingConfigurationConfigMap }}{{ .Values.homeAssistant.existingConfigurationConfigMap }}{{- else }}{{ include "home-assistant.name" . }}{{- end }}
+      {{- end }}
+      {{- if or .Values.homeAssistant.existingThemesConfigMap .Values.homeAssistant.themes }}
+        - name: themes-yaml
+          configMap:
+            name: {{ if .Values.existingThemesConfigMap }}{{ .Values.homeAssistant.existingThemesConfigMap }}{{- else }}{{ include "home-assistant.name" . }}-themes{{- end }}
+      {{- end }}
+      {{- if or .Values.homeAssistant.existingAutomationConfigMap .Values.homeAssistant.automations }}
+        - name: automation-yaml
+          configMap:
+            name: {{ if .Values.existingAutomationConfigMap }}{{ .Values.homeAssistant.existingAutomationConfigMap }}{{- else }}{{ include "home-assistant.name" . }}-automations{{- end }}
+      {{- end }}
+      {{- if or .Values.homeAssistant.existingScenesConfigMap .Values.homeAssistant.scenes }}
+        - name: scenes-yaml
+          configMap:
+            name: {{ if .Values.existingScenesConfigMap }}{{ .Values.homeAssistant.existingScenesConfigMap }}{{- else }}{{ include "home-assistant.name" . }}-scenes{{- end }}
       {{- end }}
       {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}

--- a/charts/home-assistant/templates/deployment.yaml
+++ b/charts/home-assistant/templates/deployment.yaml
@@ -110,10 +110,10 @@ spec:
           configMap:
             name: {{ if .Values.existingThemesConfigMap }}{{ .Values.homeAssistant.existingThemesConfigMap }}{{- else }}{{ include "home-assistant.name" . }}-themes{{- end }}
       {{- end }}
-      {{- if or .Values.homeAssistant.existingAutomationConfigMap .Values.homeAssistant.automations }}
+      {{- if or .Values.homeAssistant.existingAutomationsConfigMap .Values.homeAssistant.automations }}
         - name: automation-yaml
           configMap:
-            name: {{ if .Values.existingAutomationConfigMap }}{{ .Values.homeAssistant.existingAutomationConfigMap }}{{- else }}{{ include "home-assistant.name" . }}-automations{{- end }}
+            name: {{ if .Values.existingAutomationsConfigMap }}{{ .Values.homeAssistant.existingAutomationsConfigMap }}{{- else }}{{ include "home-assistant.name" . }}-automations{{- end }}
       {{- end }}
       {{- if or .Values.homeAssistant.existingScenesConfigMap .Values.homeAssistant.scenes }}
         - name: scenes-yaml

--- a/charts/home-assistant/templates/scenes-configmap.yaml
+++ b/charts/home-assistant/templates/scenes-configmap.yaml
@@ -1,0 +1,13 @@
+{{- if and (not .Values.homeAssistant.existingScenesConfigMap ) .Values.homeAssistant.scenes }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "home-assistant.fullname" . }}-scenes
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-5"
+    helm.sh/resource-policy: keep
+data:
+  scenes.yaml: |- {{ .Values.homeAssistant.scenes | nindent 4 }}
+{{- end }}

--- a/charts/home-assistant/templates/themes-configmap.yaml
+++ b/charts/home-assistant/templates/themes-configmap.yaml
@@ -1,0 +1,13 @@
+{{- if and (not .Values.homeAssistant.existingThemesConfigMap ) .Values.homeAssistant.themes }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "home-assistant.fullname" . }}-themes
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-5"
+    helm.sh/resource-policy: keep
+data:
+  themes.yaml: |- {{ .Values.homeAssistant.themes | nindent 4 }}
+{{- end }}

--- a/charts/home-assistant/values.yaml
+++ b/charts/home-assistant/values.yaml
@@ -122,10 +122,21 @@ homeAssistant:
   #     use_x_forwarded_for: true
   #     trusted_proxies:
   #       - 10.0.0.0/8
-  #
   #   mobile:
   #
   #   config:
   configuration: ""
-  # -- name of existing Config Map
-  existingConfigMap: ""
+  # -- name of existing ConfigMap
+  existingConfigurationConfigMap: ""
+  # -- contents of themes.yaml file to create
+  themes: ""
+  # -- name of existing themes ConfigMap
+  existingThemesConfigMap: ""
+  # -- contents of automations.yaml file to create
+  automations: ""
+  # -- name of existing automations ConfigMap
+  existingAutomationConfigMap: ""
+  # -- conents of scenes.yaml file to create
+  scenes: ""
+  # -- name of existing scenes ConfigMap
+  existingScenesConfigMap: ""

--- a/charts/home-assistant/values.yaml
+++ b/charts/home-assistant/values.yaml
@@ -128,15 +128,15 @@ homeAssistant:
   configuration: ""
   # -- name of existing ConfigMap
   existingConfigurationConfigMap: ""
-  # -- contents of themes.yaml file to create
+  # -- contents of themes.yaml file to create, ignored if homeAssistant.existingThemesConfigMap set
   themes: ""
   # -- name of existing themes ConfigMap
   existingThemesConfigMap: ""
-  # -- contents of automations.yaml file to create
+  # -- contents of automations.yaml file to create, ignored if homeAssistant.existingAutomationsConfigMap set
   automations: ""
   # -- name of existing automations ConfigMap
-  existingAutomationConfigMap: ""
-  # -- conents of scenes.yaml file to create
+  existingAutomationsConfigMap: ""
+  # -- conents of scenes.yaml file to create, ignored if homeAssistant.existingScenesConfigMap set
   scenes: ""
   # -- name of existing scenes ConfigMap
   existingScenesConfigMap: ""


### PR DESCRIPTION
- Home assistant docker tag bumped to `2024.4.1` via appVersion bump in Chart.yaml

- Changes the `homeAssistant.existingConfigMap` parameter to `homeAssistant.existingConfigurationConfigMap`.
  We do this to then also accept the following:

  ```yaml
  homeAssistant:
    # -- contents of themes.yaml file to create
    themes: ""
    # -- name of existing themes ConfigMap
    existingThemesConfigMap: ""
    # -- contents of automations.yaml file to create
    automations: ""
    # -- name of existing automations ConfigMap
    existingAutomationConfigMap: ""
    # -- conents of scenes.yaml file to create
    scenes: ""
    # -- name of existing scenes ConfigMap
    existingScenesConfigMap: ""
  ```