### PR TITLE
fix incorrect fields in probes and add support for service annotations

### DIFF
--- a/charts/home-assistant/templates/deployment.yaml
+++ b/charts/home-assistant/templates/deployment.yaml
@@ -89,11 +89,11 @@ spec:
           {{- end }}{{/* end check for env vars for home asisstant container */}}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
-            {{- toYaml .Values.livenessProbe | nindent 12 }}
+            {{- toYaml (omit .Values.livenessProbe "enabled") | nindent 12 }}
           {{- end }}
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
-            {{- toYaml .Values.readinessProbe | nindent 12 }}
+            {{- toYaml (omit .Values.readinessProbe "enabled") | nindent 12 }}
           {{- end }}
           {{- with .Values.resources }}
           resources:

--- a/charts/home-assistant/templates/service.yaml
+++ b/charts/home-assistant/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "home-assistant.fullname" . }}
   labels:
     {{- include "home-assistant.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/home-assistant/values.yaml
+++ b/charts/home-assistant/values.yaml
@@ -45,6 +45,7 @@ securityContext: {}
   # runAsUser: 1000
 
 service:
+  annotations: {}
   type: ClusterIP
   # -- default port to expose
   port: 80


### PR DESCRIPTION
* `livenessProbe.enabled` and `readinessProbe.enabled` are themselves being templated into the deployment object. Because those are not valid attributes, systems like ArgoCD will be perpetually out of sync. This PR fixes that.
* Additionally adds support for annotations for the service being created